### PR TITLE
Implementing Theme options for Mantis & CanHub Cropper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,33 @@ For basic examples, see `example/App.tsx`.
 | `rotationControlEnabled` | `boolean` | ✅ |  | Whether or not to show the rotation control view. Default is `true`. |
 | `cancelButtonText` | `string` | ✅ | ✅ | Custom text for the Cancel button. |
 | `doneButtonText` | `string` | ✅ | ✅ | Custom text for the Done button. |
+| `toolbarBackgroundColor` | `string` | ✅ | ✅ | Background color for the toolbar (hex format, e.g. `#00ff00` or `#00ff0080` for transparency). |
+| `toolbarForegroundColor` | `string` | ✅ | ✅ | Color for toolbar buttons and text (hex format). |
+| `cropBackgroundColor` | `string` | ✅ | ✅ | Background color for the crop area. |
+| `viewControllerBackgroundColor` | `string` | ✅ |  | iOS only - Background color for the base view layer behind the crop overlay. |
 
+### Color Format
+
+All color properties accept hex color strings in the following formats:
+- 6-digit RGB: `#00ff00` (opaque green)
+- 8-digit RGBA: `#00ff0080` (50% transparent green)
+
+Common opacity values:
+- `FF` = 100% opaque
+- `CC` = 80%
+- `80` = 50%
+- `40` = 25%
+- `00` = 0% (fully transparent)
+
+### Platform Differences
+
+**iOS** uses the Mantis library which has separate layers:
+- `cropBackgroundColor` - Controls the semi-transparent overlay around the crop area
+- `viewControllerBackgroundColor` - Controls the base background layer behind everything
+
+**Android** uses the CanHub Cropper library which has a simpler architecture:
+- `cropBackgroundColor` - Controls the background color (the cropper view is transparent)
+- `viewControllerBackgroundColor` - Not used on Android (iOS-only)
 
 ## `OpenCropperResult`
 

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
@@ -34,6 +34,26 @@ private fun Context.dpToPx(dp: Int): Int =
       resources.displayMetrics,
     ).toInt()
 
+/**
+ * Convert hex color string to Android color int.
+ * Handles both iOS format (#RRGGBBAA) and Android format (#AARRGGBB).
+ * Converts iOS format to Android format if alpha channel is detected at the end.
+ */
+private fun String.toAndroidColorInt(): Int {
+  var hex = this.trim().removePrefix("#")
+  
+  // If 8 characters (RRGGBBAA), convert to Android format (AARRGGBB)
+  if (hex.length == 8) {
+    val rr = hex.substring(0, 2)
+    val gg = hex.substring(2, 4)
+    val bb = hex.substring(4, 6)
+    val aa = hex.substring(6, 8)
+    hex = aa + rr + gg + bb
+  }
+  
+  return ("#" + hex).toColorInt()
+}
+
 class CropperActivity : AppCompatActivity() {
   private var cropView: CropImageView? = null
   private var options: OpenCropperOptions? = null
@@ -106,7 +126,11 @@ class CropperActivity : AppCompatActivity() {
       insets
     }
 
-    val root = FrameLayout(this).apply { setBackgroundColor(Color.BLACK) }
+    val root = FrameLayout(this).apply { 
+      // On Android, only cropBackgroundColor is used (viewControllerBackgroundColor is iOS-only)
+      val bgColor = options.cropBackgroundColor ?: "#000000" // default black
+      setBackgroundColor(bgColor.toAndroidColorInt())
+    }
 
     root.addView(
       cropView,
@@ -119,7 +143,10 @@ class CropperActivity : AppCompatActivity() {
     val bar =
       LinearLayout(this).apply {
         orientation = LinearLayout.HORIZONTAL
-        setBackgroundColor("#66000000".toColorInt())
+        // Apply toolbar background color or default to semi-transparent black
+        setBackgroundColor(
+          options.toolbarBackgroundColor?.toAndroidColorInt() ?: "#66000000".toColorInt()
+        )
         val dp16 = dpToPx(16)
         setPadding(0, dp16, 0, dp16) // Remove horizontal padding
         gravity = Gravity.CENTER_VERTICAL // Change to center vertical
@@ -128,7 +155,8 @@ class CropperActivity : AppCompatActivity() {
     val cancelBtn =
       AppCompatButton(this).apply {
         text = options.cancelButtonText ?: "CANCEL"
-        setTextColor(Color.WHITE)
+        // Apply foreground color or default to white
+        setTextColor(options.toolbarForegroundColor?.toAndroidColorInt() ?: Color.WHITE)
         setBackgroundColor(Color.TRANSPARENT) // Transparent background
         layoutParams =
           LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
@@ -154,8 +182,8 @@ class CropperActivity : AppCompatActivity() {
         // Set content description for accessibility
         contentDescription = "Reset"
 
-        // Make the icon white
-        setColorFilter(Color.WHITE)
+        // Apply foreground color or default to white
+        setColorFilter(options.toolbarForegroundColor?.toAndroidColorInt() ?: Color.WHITE)
 
         // Set a transparent background
         setBackgroundColor(Color.TRANSPARENT)
@@ -198,8 +226,8 @@ class CropperActivity : AppCompatActivity() {
           // Set content description for accessibility
           contentDescription = "Rotate"
 
-          // Make the icon white
-          setColorFilter(Color.WHITE)
+          // Apply foreground color or default to white
+          setColorFilter(options.toolbarForegroundColor?.toAndroidColorInt() ?: Color.WHITE)
 
           // Set a transparent background
           setBackgroundColor(Color.TRANSPARENT)
@@ -230,7 +258,8 @@ class CropperActivity : AppCompatActivity() {
     val doneBtn =
       AppCompatButton(this).apply {
         text = options.doneButtonText ?: "DONE"
-        setTextColor(Color.YELLOW)
+        // Apply foreground color or default to yellow
+        setTextColor(options.toolbarForegroundColor?.toAndroidColorInt() ?: Color.YELLOW)
         setBackgroundColor(Color.TRANSPARENT) // Transparent background
         layoutParams =
           LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
@@ -13,6 +13,9 @@ class OpenCropperOptions(
   @Field var rotationEnabled: Boolean? = true,
   @Field var cancelButtonText: String? = null,
   @Field var doneButtonText: String? = null,
+  @Field var toolbarBackgroundColor: String? = null,
+  @Field var toolbarForegroundColor: String? = null,
+  @Field var cropBackgroundColor: String? = null,
 ) : Record {
   fun toBundle(): Bundle =
     Bundle().apply {
@@ -24,6 +27,9 @@ class OpenCropperOptions(
       putBoolean("rotationEnabled", rotationEnabled ?: true)
       putString("cancelButtonText", cancelButtonText)
       putString("doneButtonText", doneButtonText)
+      putString("toolbarBackgroundColor", toolbarBackgroundColor)
+      putString("toolbarForegroundColor", toolbarForegroundColor)
+      putString("cropBackgroundColor", cropBackgroundColor)
     }
 
   companion object {
@@ -37,6 +43,9 @@ class OpenCropperOptions(
         rotationEnabled = bundle.getBoolean("rotationEnabled", true),
         cancelButtonText = bundle.getString("cancelButtonText"),
         doneButtonText = bundle.getString("doneButtonText"),
+        toolbarBackgroundColor = bundle.getString("toolbarBackgroundColor"),
+        toolbarForegroundColor = bundle.getString("toolbarForegroundColor"),
+        cropBackgroundColor = bundle.getString("cropBackgroundColor"),
       )
   }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -130,6 +130,21 @@ export default function App() {
             doCrop({
               doneButtonText: "Apply",
               cancelButtonText: "Discard",
+              toolbarBackgroundColor: "#00ff00",
+              toolbarForegroundColor: "#0000ff",
+              cropBackgroundColor: "#b700ff80",
+              viewControllerBackgroundColor: "#ff3700ff",
+            })
+          }
+        />
+        <Button
+          title="Custom Theme Options"
+          onPress={() =>
+            doCrop({
+              toolbarBackgroundColor: "#00ff00",
+              toolbarForegroundColor: "#0000ff",
+              cropBackgroundColor: "#b700ff80",
+              viewControllerBackgroundColor: "#ff3700ff",
             })
           }
         />

--- a/ios/CropperTypes.swift
+++ b/ios/CropperTypes.swift
@@ -27,6 +27,18 @@ struct OpenCropperOptions: Record {
 
   @Field
   var doneButtonText: String?
+
+  @Field
+  var toolbarBackgroundColor: String?
+
+  @Field
+  var toolbarForegroundColor: String?
+
+  @Field
+  var cropBackgroundColor: String?
+
+  @Field
+  var viewControllerBackgroundColor: String?
 }
 
 struct OpenCropperResult: Record {

--- a/src/ExpoImageCropTool.types.ts
+++ b/src/ExpoImageCropTool.types.ts
@@ -8,6 +8,10 @@ export interface OpenCropperOptions {
   rotationControlEnabled?: boolean;
   cancelButtonText?: string;
   doneButtonText?: string;
+  toolbarBackgroundColor?: string;
+  toolbarForegroundColor?: string;
+  cropBackgroundColor?: string;
+  viewControllerBackgroundColor?: string;
 }
 
 export interface OpenCropperResult {


### PR DESCRIPTION
I wanted to make some changes to the visual of the cropper view and it led me down a rabbit hole for full customization. Let me know if this is something other people would want. Examples are extravagant to clearly show what's possible.

### New Options

-  `toolbarBackgroundColor` - Controls the background color of the toolbar
-  `toolbarForegroundColor` - Controls the color of toolbar buttons and text
-  `cropBackgroundColor` - Controls the background color around the crop area
-  `viewControllerBackgroundColor` - iOS only - Controls the base background layer

### Color Format

**All colors accept hex strings:**
- 6-digit RGB: #00ff00
- 8-digit RGBA: #00ff0080 (for transparency)

### Platform Support

**iOS (Mantis library)**
- All four properties supported
- `cropBackgroundColor` controls the overlay around the crop area
- `viewControllerBackgroundColor` controls the base background layer

**Android (CanHub Cropper library)**
- Three properties supported: `toolbarBackgroundColor`, `toolbarForegroundColor`, `cropBackgroundColor`
- `viewControllerBackgroundColor` is not used on Android
- Color format automatically converts from iOS RGBA format to Android ARGB format

### Examples (visual)
<img width="901" height="330" alt="CleanShot 2025-11-10 at 13 18 17@2x" src="https://github.com/user-attachments/assets/f43bd097-6ed2-40dd-b5b4-4dec9187e3c4" />
<img width="1212" height="2332" alt="CleanShot 2025-11-10 at 13 13 10@2x" src="https://github.com/user-attachments/assets/909dd45c-db8b-4b84-91bb-ba7a8e776eaf" />
<img width="1056" height="2108" alt="CleanShot 2025-11-10 at 13 11 49@2x" src="https://github.com/user-attachments/assets/9bc9921b-331e-4cf7-8cbf-99dc050df714" />

### Real life example
<img width="1212" height="2332" alt="CleanShot 2025-11-10 at 13 54 41@2x" src="https://github.com/user-attachments/assets/22ab745e-1b45-486b-a60e-699a18b836cb" />

