### PR TITLE
Fix images going underneath safe area/toolbar

### DIFF
--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
@@ -100,29 +100,22 @@ class CropperActivity : AppCompatActivity() {
 
     this.cropView = cropView
 
-    ViewCompat.setOnApplyWindowInsetsListener(cropView) { view, insets ->
-      val sysBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-      view.setPadding(0, sysBars.top, 0, sysBars.bottom)
-      insets
-    }
-
     val root = FrameLayout(this).apply { setBackgroundColor(Color.BLACK) }
 
-    root.addView(
-      cropView,
-      FrameLayout.LayoutParams(
-        MATCH_PARENT,
-        MATCH_PARENT,
-      ),
+    val cropViewLayoutParams = FrameLayout.LayoutParams(
+      MATCH_PARENT,
+      MATCH_PARENT,
     )
+
+    root.addView(cropView, cropViewLayoutParams)
 
     val bar =
       LinearLayout(this).apply {
         orientation = LinearLayout.HORIZONTAL
         setBackgroundColor("#66000000".toColorInt())
         val dp16 = dpToPx(16)
-        setPadding(0, dp16, 0, dp16) // Remove horizontal padding
-        gravity = Gravity.CENTER_VERTICAL // Change to center vertical
+        setPadding(0, dp16, 0, dp16)
+        gravity = Gravity.CENTER_VERTICAL
       }
 
     val cancelBtn =
@@ -241,20 +234,33 @@ class CropperActivity : AppCompatActivity() {
       }
     bar.addView(doneBtn)
 
-    root.addView(
-      bar,
-      FrameLayout.LayoutParams(
-        MATCH_PARENT,
-        WRAP_CONTENT,
-        Gravity.BOTTOM,
-      ),
+    val barLayoutParams = FrameLayout.LayoutParams(
+      MATCH_PARENT,
+      WRAP_CONTENT,
+      Gravity.BOTTOM,
     )
+
+    root.addView(bar, barLayoutParams)
 
     setContentView(root)
 
     ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
-      val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-      view.setPadding(0, systemBarsInsets.top, 0, systemBarsInsets.bottom)
+      val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+      barLayoutParams.setMargins(0, 0, 0, systemBarsInsets.bottom)
+      bar.layoutParams = barLayoutParams
+
+      bar.post {
+        val toolbarHeight = bar.measuredHeight + systemBarsInsets.bottom
+        cropViewLayoutParams.setMargins(
+          systemBarsInsets.left,
+          systemBarsInsets.top,
+          systemBarsInsets.right,
+          toolbarHeight
+        )
+        cropView.layoutParams = cropViewLayoutParams
+      }
+
       insets
     }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -166,7 +166,8 @@ const styles = {
   header: {
     fontSize: 30,
     marginHorizontal: 20,
-    marginVertical: 4,
+    marginTop: 40,
+    marginBottom: 8,
   },
   text: {
     marginHorizontal: 20,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-image-crop-tool",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "An image cropper for Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Currently tall images do not respect the system bars or the toolbar. We need to add some padding to the crop view.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/e490c19a-0bb9-4f04-8261-cfbfc91a046b" />
