### PR TITLE
fix: write cropped images to caches dir on iOS

### DIFF
--- a/ios/Cropper.swift
+++ b/ios/Cropper.swift
@@ -184,9 +184,13 @@ class Cropper: NSObject, CropViewControllerDelegate {
   }
 
   private static func getTempUrl(ext: String) -> URL? {
-    let dir = FileManager().temporaryDirectory
-    return URL(
-      string: "\(dir.absoluteString)\(ProcessInfo.processInfo.globallyUniqueString).\(ext)")!
+    // Write into the caches directory rather than NSTemporaryDirectory so that
+    // consumers (e.g. expo-file-system's moveAsync) that require write access
+    // to the containing directory can move the file out.
+    guard let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+      return nil
+    }
+    return dir.appendingPathComponent("\(ProcessInfo.processInfo.globallyUniqueString).\(ext)")
   }
 
   private static func createLocalizationBundle(cancelText: String?, doneText: String?) -> Bundle? {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsky.app/expo-image-crop-tool",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "An image cropper for Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

- `getTempUrl` on iOS now writes into `.cachesDirectory` instead of `NSTemporaryDirectory`, and uses `appendingPathComponent` instead of hand-rolled URL string interpolation.
- Bumps version to 0.5.1.

## Why

Consumers that relocate the cropped file via expo-file-system's `moveAsync` were failing with:

> File '/…/tmp/UUID.jpg/..' is not writable

`moveAsync` requires write permission on the **parent** of the source file (`fromUrl.appendingPathComponent(\"..\")`). expo-modules-core only grants write permission for `cachesDirectory`, `documentDirectory`, `applicationSupportDirectory`, and app-group shared directories — `NSTemporaryDirectory()` is not on that allowlist, so the check always failed.

Android already writes into `cacheDir`, so this bug was iOS-only. The social-app manifestation: cropping an image silently returned the uncropped original (the social-app catch block fell back to the original `img` on non-cancellation errors).

Writing to the caches directory also gives the temp file a saner lifetime — iOS is much more aggressive about purging `NSTemporaryDirectory` than caches.

## Test plan

- [ ] Build social-app against 0.5.1 on iOS
- [ ] Open composer, add a photo, tap edit, crop, confirm
- [ ] Verify the cropped preview appears in the composer (no longer the original)
- [ ] Verify cancelling the cropper still works (nothing changes in the composer)
- [ ] Android regression check: crop still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)