### PR TITLE
fix android crash when crop source becomes unreadable

### DIFF
--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
@@ -285,12 +285,22 @@ class CropperActivity : AppCompatActivity() {
         }
 
     val bmap =
-      cropView?.getCroppedImage()
-        ?: run {
-          setResult(CropperError.GetData.getResultCode(), null)
-          finish()
-          return
-        }
+      try {
+        cropView?.getCroppedImage()
+      } catch (e: Exception) {
+        // getCroppedImage re-reads the full-resolution region from the source
+        // content:// URI, which can fail even though the image displayed fine
+        // (revoked permission grant, the file was deleted or moved while the
+        // cropper was open, or a provider that rejects the re-read). That
+        // throws CropException.FailedToLoadBitmap. Fail the crop gracefully
+        // instead of letting it crash the whole app.
+        Log.e("ExpoCropTool", "Error loading image for crop", e)
+        null
+      } ?: run {
+        setResult(CropperError.GetData.getResultCode(), null)
+        finish()
+        return
+      }
 
     try {
       val format = options.format ?: "png"


### PR DESCRIPTION
## Problem

Sharing media into the app and cropping it can crash the whole app on Android:

```
Caused by com.canhub.cropper.CropException$FailedToLoadBitmap:
  at com.canhub.cropper.BitmapUtils.cropBitmap (BitmapUtils.kt:677)
  ...
  at com.canhub.cropper.CropImageView.getCroppedImage (CropImageView.kt:623)
  at xyz.blueskyweb.expoimagecroptool.CropperActivity.onDone (CropperActivity.kt:288)
  at xyz.blueskyweb.expoimagecroptool.CropperActivity.onCreate$lambda$21$lambda$20 (CropperActivity.kt:233)
```

For large images the cropper only loads a downsampled bitmap for display, so the initial load succeeds. When the user taps Done, `getCroppedImage()` goes back and re-reads the full-resolution region from the original `content://` URI. That second read can fail even though the image displayed fine:

- the temporary URI permission grant was revoked,
- the file was deleted or moved while the cropper was open, or
- the provider (e.g. a cloud-backed one) rejects the re-read.

The cropper then throws `CropException.FailedToLoadBitmap`.

The `getCroppedImage()` call sat *outside* the existing `try/catch` in `onDone()`, so the exception propagated out of the click handler and crashed the app instead of just failing the crop.

## Fix

Wrap the `getCroppedImage()` call and fail gracefully with the existing `GetData` error code, which already flows back through the JS layer. No new error code or behavior change for the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)